### PR TITLE
Fix typo in zrevrangebyscore method

### DIFF
--- a/src/main/java/redis/clients/jedis/CommandObjects.java
+++ b/src/main/java/redis/clients/jedis/CommandObjects.java
@@ -1516,7 +1516,7 @@ public class CommandObjects {
   }
 
   public final CommandObject<List<String>> zrevrangeByScore(String key, String max, String min, int offset, int count) {
-    return new CommandObject<>(commandArguments(ZRANGEBYSCORE).key(key).add(max).add(min)
+    return new CommandObject<>(commandArguments(ZREVRANGEBYSCORE).key(key).add(max).add(min)
         .add(LIMIT).add(offset).add(count), BuilderFactory.STRING_LIST);
   }
 

--- a/src/test/java/redis/clients/jedis/commands/jedis/SortedSetCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/SortedSetCommandsTest.java
@@ -859,6 +859,13 @@ public class SortedSetCommandsTest extends JedisCommandsTestBase {
 
     assertEquals(expected, range);
 
+    range = jedis.zrevrangeByScore("foo", "4", "2", 0, 2);
+    expected = new ArrayList<String>();
+    expected.add("d");
+    expected.add("c");
+
+    assertEquals(expected, range);
+
     range = jedis.zrevrangeByScore("foo", "+inf", "(4");
     expected = new ArrayList<String>();
     expected.add("e");

--- a/src/test/java/redis/clients/jedis/commands/unified/SortedSetCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/SortedSetCommandsTestBase.java
@@ -916,6 +916,13 @@ public abstract class SortedSetCommandsTestBase extends UnifiedJedisCommandsTest
 
     assertEquals(expected, range);
 
+    range = jedis.zrevrangeByScore("foo", "4", "2", 0, 2);
+    expected = new ArrayList<String>();
+    expected.add("d");
+    expected.add("c");
+
+    assertEquals(expected, range);
+
     range = jedis.zrevrangeByScore("foo", "+inf", "(4");
     expected = new ArrayList<String>();
     expected.add("e");


### PR DESCRIPTION
This PR is to fix the typo in this method
`public final CommandObject<List<String>> zrevrangeByScore(String key, String max, String min, int offset, int count) ...
`
instead of calling the ZREVRANGEBYSCORE its calling ZRANGEBYSCORE. 